### PR TITLE
[MH2018-8] --> [MH-Team-2-Shopify] BugFix/footer-share-icons

### DIFF
--- a/Lil-Peep/src/snippets/social-sharing-footer.liquid
+++ b/Lil-Peep/src/snippets/social-sharing-footer.liquid
@@ -9,7 +9,7 @@
   </div>
 
   <div class="sm icon-social-media">
-    {{ 'gPlus.png' | asset_url | img_tag | link_to: 'https://plus.google.com/?hl=es', 'Google Plus' }}
+    {{ 'gplus.png' | asset_url | img_tag | link_to: 'https://plus.google.com/?hl=es', 'Google Plus' }}
   </div>
 
 </div>


### PR DESCRIPTION
## Footer icons from task [MH2018-8]

## Before:
<img width="325" alt="captura de pantalla 2018-04-02 a la s 13 30 50" src="https://user-images.githubusercontent.com/23444805/38209933-7f67e452-367b-11e8-827f-b3b05e7dbe1d.png">

## After:
<img width="342" alt="captura de pantalla 2018-04-02 a la s 13 31 19" src="https://user-images.githubusercontent.com/23444805/38209936-816106f8-367b-11e8-89f3-0a4b5c99e11d.png">
