### PR TITLE
[MH2018-17] --> [MH-Team-2-Shopify] bugFix/breadcumbs

### DIFF
--- a/Lil-Peep/src/locales/en.default.json
+++ b/Lil-Peep/src/locales/en.default.json
@@ -223,7 +223,8 @@
       "product_title": "Example Product Title",
       "collection_title": "Example Collection Title",
       "no_content": "This section doesn’t currently include any content. Add content to this section using the sidebar.",
-      "featured-products": "FEATURED TOYS"
+      "featured-products": "FEATURED TOYS",
+      "home_breadcrumb": "HOME"
     }
   },
   "layout": {

--- a/Lil-Peep/src/sections/product.liquid
+++ b/Lil-Peep/src/sections/product.liquid
@@ -1,12 +1,4 @@
-<div class="current-route-container">
-  <section class="current-route">
-    <a class="home-route-section">HOME</a>
-    {% if collection.title != blank %}
-      <a class="home-route-section">&gt; {{ collection.title | upcase}}</a>
-    {% endif %}
-    <a class="categories-route-section">&gt; {{ product.title | upcase}}</a>
-  </section>
-</div>
+{%- include 'breadcrumb' -%}
 
 <div class="product-container" data-section-id="{{ section.id }}" data-section-type="product" data-enable-history-state="true" itemscope itemtype="http://schema.org/Product">
 

--- a/Lil-Peep/src/snippets/body-collection.liquid
+++ b/Lil-Peep/src/snippets/body-collection.liquid
@@ -5,12 +5,7 @@
   </div>
 </section>
 
-<div class="current-route-container">
-  <section class="current-route">
-      <a class="home-route-section">HOME</a>
-      <a class="categories-route-section">&gt; {{ collection.title | upcase}}</a>
-  </section>
-</div>
+{%- include 'breadcrumb' -%}
 
 <div class="categories-view">
 

--- a/Lil-Peep/src/snippets/breadcrumb.liquid
+++ b/Lil-Peep/src/snippets/breadcrumb.liquid
@@ -1,0 +1,11 @@
+<div class="current-route-container">
+  <section class="current-route">
+    <a class="home-route-section" href="/">{{ 'homepage.onboarding.home_breadcrumb' | t }}</a>
+    {% if collection.title != blank %}
+      <a class="home-route-section" href="{{collection.url}}">&gt; {{ collection.title | upcase}}</a>
+    {% endif %}
+    {% if product.title != blank %}
+      <a class="categories-route-section">&gt; {{ product.title | upcase}}</a>
+    {% endif %}
+  </section>
+</div>

--- a/Lil-Peep/src/styles/modules/site-collection.scss
+++ b/Lil-Peep/src/styles/modules/site-collection.scss
@@ -77,6 +77,7 @@
 
     .home-route-section {
       color: #{$home-route-section};
+      text-decoration: none;
     }
 
     .categories-route-section {

--- a/Lil-Peep/src/styles/modules/site-collection.scss
+++ b/Lil-Peep/src/styles/modules/site-collection.scss
@@ -1,5 +1,5 @@
 .desktop {
-  background-color: #{$background-color};
+  background-color: $background-color;
 
   @media #{$breakpoint-mobile} {
     display: none;
@@ -7,7 +7,7 @@
 }
 
 .mobile {
-  background-color: #{$background-color};
+  background-color: $background-color;
 
   @media #{$breakpoint-tablet} {
     display: none;
@@ -20,15 +20,15 @@
 
 .info-dialog {
   align-items: center;
-  background-color: #{$info-dialog-color};
+  background-color: $info-dialog-color;
   display: flex;
   height: 35px;
   justify-content: center;
   position: relative;
 
   p {
-    color: #{$color-body};
-    font-family: 'Oswald', sans-serif;
+    color: $color-body;
+    font-family: $oswald-font;
     font-size: 12px;
     margin: 2px;
   }
@@ -43,10 +43,10 @@
     width: 100%;
 
     button {
-      background-color: #{$color-body};
+      background-color: $color-body;
       border-radius: 50%;
       border-style: none;
-      color: #abc828;
+      color: $info-dialog-color;
       font-weight: bold;
       height: 20px;
       text-align: center;
@@ -60,7 +60,7 @@
 }
 
 .current-route-container {
-  background-color: #{$background-color};
+  background-color: $background-color;
   padding-top: 10px;
   padding-bottom: 20px;
   width: 100%;
@@ -72,23 +72,23 @@
 
   @media #{$breakpoint-tablet} {
     display: block;
-    font-family: 'Lato', sans-serif;
+    font-family: $lato-font;
     margin-top: 20px;
 
     .home-route-section {
-      color: #{$home-route-section};
+      color: $home-route-section;
       text-decoration: none;
     }
 
     .categories-route-section {
-      color: #{$categories-route-section};
+      color: $categories-route-section;
     }
   }
 }
 
 .categories-view {
-  background-color: #{$background-color};
-  font-family: 'Oswald', sans-serif;
+  background-color: $background-color}
+  font-family: $oswald-font;
   margin-bottom: 0;
   padding-bottom: 20px;
   padding-left: 30px;
@@ -101,7 +101,7 @@
 }
 
   h1 {
-    font-family: 'Lato', sans-serif;
+    font-family: $lato-font;
     text-align: center;
   }
 
@@ -112,12 +112,12 @@
     padding-left: 30px;
     padding-right: 30px;
 
-    @media #{$breakpoint-mobile} {
+    @media $breakpoint-mobile {
       justify-content: space-between;
     }
 
     .active-button {
-      color: #{$active-button};
+      color: $active-button;
       display: inline;
       font-size: 30px;
       text-decoration: none;
@@ -128,7 +128,7 @@
     }
 
     .blocked-button {
-      color: #{$active-button};
+      color: $active-button;
       display: inline;
       font-size: 30px;
       opacity: 0.5;
@@ -154,7 +154,7 @@
   }
 
   .product-card-category {
-    background-color: #{$product-card-category};
+    background-color: $product-card-category;
     flex: 1 0 20%;
     height: 470px;
     margin: 10px;
@@ -170,15 +170,15 @@
       width: 100%;
 
       .new-product {
-        background-color: #{$info-dialog-color};
+        background-color: $info-dialog-color;
         border-radius: 3px;
-        color: #{$color-body};
+        color: $color-body;
         font-weight: bold;
         padding: 5px 25px;
       }
 
       .not-new-product {
-        color: #{$product-card-category};
+        color: $product-card-category;
         opacity: 0;
         padding: 5px 25px;
       }
@@ -205,19 +205,19 @@
   padding-right: 15px;
 
   p {
-    font-family: 'Lato', sans-serif;
+    font-family: $lato-font;
     margin-bottom: 5px;
     margin-top: 0;
   }
 
   .product-title {
-    color: #{$active-button};
+    color: $active-button;
     font-weight: bold;
     text-decoration: none;
   }
 
   .view-in-detail {
-    background-color: #{$view-green};
+    background-color: $view-green;
     border-radius: 3px;
     border-style: none;
     padding: 10px 0;
@@ -225,7 +225,7 @@
     width: 100%;
 
     &:hover {
-      background-color: #{$on-hover-button};
+      background-color: $on-hover-button;
       cursor: pointer;
     }
 
@@ -234,16 +234,16 @@
     }
 
     h4 {
-      background-color: #{$view-green};
-      color: #{$color-body};
-      font-family: 'Oswald', sans-serif;
+      background-color: $view-green;
+      color: $color-body;
+      font-family: $oswald-font;
       font-weight: bold;
       margin: 0;
     }
   }
 
   .price {
-    color: #{$price-purple};
+    color: $price-purple;
 
     @media #{$breakpoint-tablet} {
       display: flex;
@@ -254,7 +254,7 @@
     display: none;
 
     @media #{$breakpoint-tablet} {
-      color: #{$price-gray};
+      color: $price-gray;
       display: flex;
       margin-left: 5px;
       text-decoration: line-through;
@@ -283,7 +283,7 @@
     text-decoration: none;
 
     .title {
-      font-family:  $Oswald;
+      font-family: $oswald-font;
       font-size: 16px;
       font-weight: normal;
     }

--- a/Lil-Peep/src/styles/modules/site-collection.scss
+++ b/Lil-Peep/src/styles/modules/site-collection.scss
@@ -87,7 +87,7 @@
 }
 
 .categories-view {
-  background-color: $background-color}
+  background-color: $background-color;
   font-family: $oswald-font;
   margin-bottom: 0;
   padding-bottom: 20px;
@@ -112,7 +112,7 @@
     padding-left: 30px;
     padding-right: 30px;
 
-    @media $breakpoint-mobile {
+    @media #{$breakpoint-mobile} {
       justify-content: space-between;
     }
 

--- a/Lil-Peep/src/styles/settings/variables.scss.liquid
+++ b/Lil-Peep/src/styles/settings/variables.scss.liquid
@@ -59,6 +59,7 @@ $color-error-bg: #000;
 $color-success: #000;
 $color-success-bg: #000;
 $lato-font: 'Lato', sans-serif;
+$oswald-font: 'Oswald', sans-serif;
 
 /*================ Typography Variables ================*/
 $font-weight-normal: 400;


### PR DESCRIPTION
## Breadcrumbs refactorization due to a new snippet creation.

### Now, it has linkable capabilities.
<img width="400" alt="captura de pantalla 2018-04-02 a la s 17 31 39" src="https://user-images.githubusercontent.com/23444805/38219878-632a2c24-369d-11e8-93e6-cb6767499555.png">

## For example:
<img width="730" alt="captura de pantalla 2018-04-02 a la s 17 32 38" src="https://user-images.githubusercontent.com/23444805/38219900-753cc84a-369d-11e8-83d8-2914bbbd87dd.png">
